### PR TITLE
Setup monitoring for downstream ariadne api endpoints

### DIFF
--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -37,8 +37,8 @@ applications:
     url: 'https://dev.login.library.nyu.edu'
     expected_status: 200
   - name: salon
-    url: 'https://persistent-dev.library.nyu.edu/arch'
-    expected_status: 404
+    url: 'https://persistent-dev.library.nyu.edu/arch/does-not-ever-exist'
+    expected_status: 400
   - name: specialcollections
     url: 'https://specialcollections-dev.library.nyu.edu/search'
     expected_status: 200

--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -6,17 +6,23 @@ applications:
     url: 'https://dev.library.nyu.edu/persistent'
     expected_status: 301
     expected_location: 'https://app.library.nyu.edu/bobcat-linker'
+  - name: bobcat-standard
+    url: 'https://alephstage.library.nyu.edu'
+    expected_status: 200
   - name: campus-media-equipment
     url: 'https://dev.library.nyu.edu/services/campus-media/classrooms/'
     expected_status: 200
   - name: getit
-    url: 'https://getit-dev.library.nyu.edu/'
+    url: 'https://getit-dev.library.nyu.edu'
     expected_status: 301
     expected_location: 'https://bobcat.library.nyu.edu/primo-explore/citationlinker?vid=NYU'
   - name: getit-ebooks
     url: 'https://getit-dev.library.nyu.edu/v0/?genre=bookitem&isbn=9780190280390&issn=&title=Our%20Lady%20of%20everyday%20life:%20la%20Virgen%20de%20Guadalupe%20and%20the%20Catholic%20imagination%20of%20Mexican%20women%20in%20America&volume=&issue=&date=20180101&atitle=&aulast=&spage=&sid=EBSCO:Chicano%20Database&pid=XCHD8493320180101Chicano%20Database'
     expected_status: 200
     expected_content: 'ebookcentral.proquest.com'
+  - name: illiad
+    url: 'https://dev.ill.library.nyu.edu'
+    expected_status: 200
   - name: libcal-assets
     url: 'https://cdn-dev.library.nyu.edu/libcal/index.min.js'
     expected_status: 200
@@ -24,19 +30,19 @@ applications:
     url: 'https://cdn-dev.library.nyu.edu/libguides/index.min.js'
     expected_status: 200
   - name: library-nyu-edu
-    url: 'http://dev.library.nyu.edu/'
+    url: 'http://dev.library.nyu.edu'
     expected_status: 301
     expected_location: 'https://dev.library.nyu.edu/'
   - name: login
-    url: 'https://dev.login.library.nyu.edu/'
+    url: 'https://dev.login.library.nyu.edu'
     expected_status: 200
+  - name: salon
+    url: 'https://persistent-dev.library.nyu.edu/arch'
+    expected_status: 404
   - name: specialcollections
     url: 'https://specialcollections-dev.library.nyu.edu/search'
     expected_status: 200
   - name: statuspage-embed
     url: 'https://cdn-dev.library.nyu.edu/statuspage-embed/index.min.js'
     expected_status: 200
-  - name: ebookcentral
-    url: 'https://getit-dev.library.nyu.edu/v0/?genre=bookitem&isbn=9780190280390&issn=&title=Our%20Lady%20of%20everyday%20life:%20la%20Virgen%20de%20Guadalupe%20and%20the%20Catholic%20imagination%20of%20Mexican%20women%20in%20America&volume=&issue=&date=20180101&atitle=&aulast=&spage=&sid=EBSCO:Chicano%20Database&pid=XCHD8493320180101Chicano%20Database'
-    expected_status: 200
-    expected_content: 'ebookcentral.proquest.com'
+

--- a/config/prod.applications.yml
+++ b/config/prod.applications.yml
@@ -61,8 +61,8 @@ applications:
     url: 'https://cite.library.nyu.edu/healthcheck'
     expected_status: 200
   - name: salon
-    url: 'https://persistent.library.nyu.edu/arch/'
-    expected_status: 404
+    url: 'https://persistent.library.nyu.edu/arch/does-not-ever-exist'
+    expected_status: 400
   - name: sfx
     url: 'http://sfx.library.nyu.edu/sfxlcl41'
     expected_status: 200

--- a/config/prod.applications.yml
+++ b/config/prod.applications.yml
@@ -6,6 +6,9 @@ applications:
     url: 'https://library.nyu.edu/persistent'
     expected_status: 301
     expected_location: 'https://app.library.nyu.edu/bobcat-linker'
+  - name: bobcat-standard
+    url: 'https://aleph.library.nyu.edu'
+    expected_status: 200
   - name: campus-media-equipment
     url: 'https://library.nyu.edu/services/campus-media/classrooms/'
     expected_status: 200
@@ -47,12 +50,14 @@ applications:
     expected_status: 301
     expected_location: 'https://bobcat.library.nyu.edu/primo-explore/search?vid=NYU'
   - name: pushtocite
-    url: 'https://cite.library.nyu.edu/'
-    expected_status: 400
+    url: 'https://cite.library.nyu.edu/healthcheck'
+    expected_status: 200
   - name: salon
-    url: 'https://persistent.library.nyu.edu'
-    expected_status: 301
-    expected_location: 'http://persistent.library.nyu.edu/arch'
+    url: 'https://persistent.library.nyu.edu/arch/'
+    expected_status: 404
+  - name: sfx
+    url: 'http://sfx.library.nyu.edu/sfxlcl41'
+    expected_status: 200
   - name: specialcollections
     url: 'https://specialcollections.library.nyu.edu/search/'
     expected_status: 200

--- a/config/prod.applications.yml
+++ b/config/prod.applications.yml
@@ -24,6 +24,14 @@ applications:
     url: 'https://getit.library.nyu.edu/v0/?genre=bookitem&isbn=9780190280390&issn=&title=Our%20Lady%20of%20everyday%20life:%20la%20Virgen%20de%20Guadalupe%20and%20the%20Catholic%20imagination%20of%20Mexican%20women%20in%20America&volume=&issue=&date=20180101&atitle=&aulast=&spage=&sid=EBSCO:Chicano%20Database&pid=XCHD8493320180101Chicano%20Database'
     expected_status: 200
     expected_content: 'ebookcentral.proquest.com'
+  - name: getit-ebook-primo-api
+    url: 'https://bobcat.library.nyu.edu/primo_library/libweb/webservices/rest/primo-explore/v1/pnxs?inst=NYU&limit=50&offset=0&q=isbn%2Cexact%2C9780190280390&scope=all&vid=NYU'
+    expected_status: 200
+    expected_content: 'academic.oup.com'
+  - name: getit-ebook-sfx-api
+    url: 'http://sfx.library.nyu.edu/sfxlcl41?genre=bookitem&atitle=&aulast=&date=20180101&isbn=9780190280390&issn=&issue=&pid=XCHD8493320180101Chicano+Database&rfr_id=EBSCO%3AChicano+Database&sfx.doi_url=http%3A%2F%2Fdx.doi.org&sfx.response_type=multi_obj_xml&spage=&title=Our+Lady+of+everyday+life%3A+la+Virgen+de+Guadalupe+and+the+Catholic+imagination+of+Mexican+women+in+America&url_ctx_fmt=info%3Aofi%2Ffmt%3Axml%3Axsd%3Actx&volume='
+    expected_status: 200
+    expected_content: 'ill.library.nyu.edu'
   - name: libcal-assets
     url: 'https://cdn.library.nyu.edu/libcal/index.min.js'
     expected_status: 200


### PR DESCRIPTION
Setup tests of SFX and Primo API endpoints used by Ariadne:
getit-ebook-sfx-api
getit-ebook-primo-api