### PR TITLE
fix(config): Add whitelist and sanitization to loadConfig; update tests

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	a "github.com/NYULibraries/aswa/lib/application"
+	c "github.com/NYULibraries/aswa/lib/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -277,6 +278,8 @@ func TestCheckDo(t *testing.T) {
 			os.Setenv(envYamlPath, tt.envYamlPath)
 			os.Setenv(envSlackWebhookUrl, tt.envSlackUrl)
 			os.Setenv(envClusterInfo, tt.envClusterInfo)
+			// Set environment variable to true for this test
+			os.Setenv(c.EnvSkipWhitelistCheck, "true")
 			os.Args = tt.cmdArgs
 
 			// Initialize Check struct with a logger that outputs to stdout.
@@ -297,6 +300,7 @@ func TestCheckDo(t *testing.T) {
 			os.Unsetenv(envYamlPath)
 			os.Unsetenv(envSlackWebhookUrl)
 			os.Unsetenv(envClusterInfo)
+			os.Unsetenv(c.EnvSkipWhitelistCheck)
 		})
 	}
 }

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	a "github.com/NYULibraries/aswa/lib/application"
 	"github.com/stretchr/testify/assert"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 )
@@ -37,7 +38,11 @@ func TestNewConfig(t *testing.T) {
 
 func testNewConfigFunc(path string, expectedErr string) func(*testing.T) {
 	return func(t *testing.T) {
+		// Set environment variable to true for this test
+		os.Setenv(EnvSkipWhitelistCheck, "true")
 		_, err := NewConfig(path)
+
+		os.Unsetenv(EnvSkipWhitelistCheck)
 		if expectedErr == "" {
 			assert.Nil(t, err)
 		} else {


### PR DESCRIPTION
Fix a bug in the `loadConfig` function concerning whitelist checking and 
data sanitization:
[CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')](https://cwe.mitre.org/data/definitions/22.html)

- Ensure only allowed file paths are processed
- Sanitize incoming data to prevent potential security risks