### PR TITLE
Add CSP header check

### DIFF
--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -86,7 +86,7 @@ func RunSyntheticTests(appData []*a.Application, targetAppName string) error {
 			found = true // The app was found in the config file
 			appStatus := app.GetStatus()
 			log.Println(appStatus)
-			if !appStatus.StatusOk || !appStatus.StatusContentOk {
+			if !appStatus.StatusOk || !appStatus.StatusContentOk || !appStatus.StatusCSPOk {
 				failingSyntheticTests = append(failingSyntheticTests, FailingSyntheticTest{App: app, AppStatus: *appStatus})
 			}
 

--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -44,6 +44,10 @@ applications:
   - name: dev-login
     url: 'https://dev.login.library.nyu.edu'
     expected_status: 200
+  - name: primo-ve
+    url: 'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU_DEV'
+    expected_status: 200
+    expected_csp: "object-srcc blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
   - name: salon
     url: 'https://persistent-dev.library.nyu.edu/arch/does-not-ever-exist'
     expected_status: 400

--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -47,7 +47,7 @@ applications:
   - name: primo-ve
     url: 'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU_DEV'
     expected_status: 200
-    expected_csp: "object-srcc blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
+    expected_csp: "object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
   - name: salon
     url: 'https://persistent-dev.library.nyu.edu/arch/does-not-ever-exist'
     expected_status: 400

--- a/config/prod.applications.yml
+++ b/config/prod.applications.yml
@@ -50,6 +50,10 @@ applications:
     url: 'http://library.nyu.edu/'
     expected_status: 301
     expected_location: 'https://library.nyu.edu/'
+  - name: primo-ve
+    url: 'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU'
+    expected_status: 200
+    expected_csp: "object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
   - name: prod-login
     url: 'https://login.library.nyu.edu/'
     expected_status: 200

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -40,21 +40,25 @@ func TestGetStatus(t *testing.T) {
 		expectedActualLocation   string
 		expectedContentSuccess   bool
 		expectedActualContent    string
+		//expectedCSPSuccess       bool
+		expectedActualCSP string
 	}{
-		{"Success: correct redirect expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "https://library.nyu.edu/", ""}, true, http.StatusMovedPermanently, "https://library.nyu.edu/", true, ""},
-		{"Failure: wrong redirect expected", &Application{"", "http://library.nyu.edu", http.StatusFound, 800 * time.Millisecond, "", ""}, false, http.StatusMovedPermanently, "", true, ""},
-		{"Success: correct error expected", &Application{"", "https://library.nyu.edu/nopageexistshere", http.StatusNotFound, 600 * time.Millisecond, "", ""}, true, http.StatusNotFound, "", true, ""},
-		{"Success: success status code expected", &Application{"", "https://library.nyu.edu", http.StatusOK, 800 * time.Millisecond, "", ""}, true, http.StatusOK, "", true, ""},
-		{"Failure: wrong status code expected", &Application{"", mockServer.URL + "/wrongstatus", http.StatusOK, 800 * time.Millisecond, "", ""}, false, http.StatusNotFound, "", true, ""},
-		{"Failure: application is down", &Application{"", mockServer.URL + "/500", http.StatusOK, 800 * time.Millisecond, "", ""}, false, http.StatusInternalServerError, "", true, ""},
-		{"Success: timeout", &Application{"", "https://library.nyu.edu", http.StatusOK, 200 * time.Millisecond, "", ""}, true, http.StatusOK, "", true, ""},
-		{"Failure: timeout", &Application{"", mockServer.URL + "/slowresponse", http.StatusOK, 1 * time.Millisecond, "", ""}, false, 0, "", false, ""},
-		{"Success: correct redirect expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "https://library.nyu.edu/", ""}, true, http.StatusMovedPermanently, "https://library.nyu.edu/", true, ""},
-		{"Failure: wrong redirect expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "http://library.nyu.edu/", ""}, false, http.StatusMovedPermanently, "https://library.nyu.edu/", true, ""},
-		{"Failure: wrong redirect location expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "http://library.nyu.edu/", ""}, false, http.StatusMovedPermanently, "https://library.nyu.edu/", true, ""},
-		{"Failure: wrong error expected", &Application{"", "https://library.nyu.edu/nopageexistshere", http.StatusFound, 800 * time.Millisecond, "", ""}, false, http.StatusNotFound, "", true, ""},
-		{"Success: expected content found", &Application{"", mockServer.URL + "/html", http.StatusOK, 5 * time.Second, "", "Herman Melville"}, true, http.StatusOK, "", true, "Herman Melville"},
-		{"Failure: expected content not found", &Application{"", mockServer.URL + "/html", http.StatusOK, 5 * time.Second, "", "Jules Verne - 20,000 Leagues Under the Sea"}, true, http.StatusOK, "", false, ""},
+		{"Success: correct redirect expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "https://library.nyu.edu/", "", ""}, true, http.StatusMovedPermanently, "https://library.nyu.edu/", true, "", ""},
+		{"Failure: wrong redirect expected", &Application{"", "http://library.nyu.edu", http.StatusFound, 800 * time.Millisecond, "", "", ""}, false, http.StatusMovedPermanently, "", true, "", ""},
+		{"Success: correct error expected", &Application{"", "https://library.nyu.edu/nopageexistshere", http.StatusNotFound, 600 * time.Millisecond, "", "", ""}, true, http.StatusNotFound, "", true, "", ""},
+		{"Success: success status code expected", &Application{"", "https://library.nyu.edu", http.StatusOK, 800 * time.Millisecond, "", "", ""}, true, http.StatusOK, "", true, "", ""},
+		{"Failure: wrong status code expected", &Application{"", mockServer.URL + "/wrongstatus", http.StatusOK, 800 * time.Millisecond, "", "", ""}, false, http.StatusNotFound, "", true, "", ""},
+		{"Failure: application is down", &Application{"", mockServer.URL + "/500", http.StatusOK, 800 * time.Millisecond, "", "", ""}, false, http.StatusInternalServerError, "", true, "", ""},
+		{"Success: timeout", &Application{"", "https://library.nyu.edu", http.StatusOK, 200 * time.Millisecond, "", "", ""}, true, http.StatusOK, "", true, "", ""},
+		{"Failure: timeout", &Application{"", mockServer.URL + "/slowresponse", http.StatusOK, 1 * time.Millisecond, "", "", ""}, false, 0, "", false, "", ""},
+		{"Success: correct redirect expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "https://library.nyu.edu/", "", ""}, true, http.StatusMovedPermanently, "https://library.nyu.edu/", true, "", ""},
+		{"Failure: wrong redirect expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "http://library.nyu.edu/", "", ""}, false, http.StatusMovedPermanently, "https://library.nyu.edu/", true, "", ""},
+		{"Failure: wrong redirect location expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "http://library.nyu.edu/", "", ""}, false, http.StatusMovedPermanently, "https://library.nyu.edu/", true, "", ""},
+		{"Failure: wrong error expected", &Application{"", "https://library.nyu.edu/nopageexistshere", http.StatusFound, 800 * time.Millisecond, "", "", ""}, false, http.StatusNotFound, "", true, "", ""},
+		{"Success: expected content found", &Application{"", mockServer.URL + "/html", http.StatusOK, 5 * time.Second, "", "Herman Melville", ""}, true, http.StatusOK, "", true, "Herman Melville", ""},
+		{"Failure: expected content not found", &Application{"", mockServer.URL + "/html", http.StatusOK, 5 * time.Second, "", "Jules Verne - 20,000 Leagues Under the Sea", ""}, true, http.StatusOK, "", false, "", ""},
+		{"Success: expected CSP header found", &Application{"", mockServer.URL + "/html", http.StatusOK, 5 * time.Second, "", "", "default-src 'self'"}, true, http.StatusOK, "", true, "", "default-src 'self'"},
+		{"Failure: expected CSP header not found", &Application{"", mockServer.URL + "/html", http.StatusOK, 5 * time.Second, "", "", "default-src 'none'"}, true, http.StatusOK, "", true, "", ""},
 	}
 
 	for _, test := range tests {
@@ -161,6 +165,7 @@ func TestCreateApplicationStatus(t *testing.T) {
 				Application:      &app,
 				StatusOk:         true,
 				StatusContentOk:  true,
+				StatusCSPOk:      true,
 				ActualStatusCode: http.StatusOK,
 				ActualLocation:   "",
 				ActualContent:    "Successful Request",
@@ -175,6 +180,7 @@ func TestCreateApplicationStatus(t *testing.T) {
 				Application:      &appWithoutContent,
 				StatusOk:         true,
 				StatusContentOk:  true,
+				StatusCSPOk:      true,
 				ActualStatusCode: http.StatusOK,
 				ActualLocation:   "",
 				ActualContent:    "",
@@ -221,12 +227,12 @@ func TestString(t *testing.T) {
 		appStatus      *ApplicationStatus
 		expectedOutput string
 	}{
-		{description: "Successful status", appStatus: &ApplicationStatus{Application: &Application{"", "https://library.nyu.edu", http.StatusOK, time.Second, "", ""}, StatusOk: true, StatusContentOk: true, ActualStatusCode: 200}, expectedOutput: "Success: URL https://library.nyu.edu resolved with 200"},
+		{description: "Successful status", appStatus: &ApplicationStatus{Application: &Application{"", "https://library.nyu.edu", http.StatusOK, time.Second, "", "", ""}, StatusOk: true, StatusContentOk: true, ActualStatusCode: 200}, expectedOutput: "Success: URL https://library.nyu.edu resolved with 200"},
 		{description: "Failed status", appStatus: &ApplicationStatus{Application: &Application{URL: "https://library.nyu.edu", ExpectedStatusCode: http.StatusOK, Timeout: time.Second}, StatusOk: false, StatusContentOk: true, ActualStatusCode: 404}, expectedOutput: "Failure: URL https://library.nyu.edu resolved with 404, expected 200"},
 		{description: "Successful status with location", appStatus: &ApplicationStatus{Application: &Application{URL: "http://library.nyu.edu", ExpectedStatusCode: http.StatusMovedPermanently, Timeout: time.Second, ExpectedLocation: "https://library.nyu.edu/"}, StatusOk: true, StatusContentOk: true, ActualStatusCode: 301, ActualLocation: "https://library.nyu.edu/"}, expectedOutput: "Success: URL http://library.nyu.edu resolved with 301, redirect location matched https://library.nyu.edu/"},
 		{description: "Failed status with location", appStatus: &ApplicationStatus{Application: &Application{URL: "http://library.nyu.edu", ExpectedStatusCode: http.StatusMovedPermanently, Timeout: time.Second, ExpectedLocation: "http://library.nyu.edu/"}, StatusOk: false, StatusContentOk: true, ActualStatusCode: 301, ActualLocation: "https://library.nyu.edu/"}, expectedOutput: "Failure: URL http://library.nyu.edu resolved with 301, but redirect location https://library.nyu.edu/ did not match http://library.nyu.edu/"},
-		{description: "Successful status with expected content", appStatus: &ApplicationStatus{Application: &Application{"", "https://example.com", http.StatusOK, time.Second, "", "Example Domain"}, StatusOk: true, StatusContentOk: true, ActualStatusCode: 200, ActualContent: "Example Domain"}, expectedOutput: "Success: URL https://example.com resolved with 200\nSuccess: ExpectedContent Example Domain matched ActualContent Example Domain"},
-		{description: "Failed status with unexpected content", appStatus: &ApplicationStatus{Application: &Application{"", "https://example.com", http.StatusOK, time.Second, "", "Wrong Content"}, StatusOk: true, StatusContentOk: false, ActualStatusCode: 200, ActualContent: "Example Domain"}, expectedOutput: "Success: URL https://example.com resolved with 200\nFailure: Expected content Wrong Content did not match ActualContent"},
+		{description: "Successful status with expected content", appStatus: &ApplicationStatus{Application: &Application{"", "https://example.com", http.StatusOK, time.Second, "", "Example Domain", ""}, StatusOk: true, StatusContentOk: true, ActualStatusCode: 200, ActualContent: "Example Domain"}, expectedOutput: "Success: URL https://example.com resolved with 200\nSuccess: ExpectedContent Example Domain matched ActualContent Example Domain\n"},
+		{description: "Failed status with unexpected content", appStatus: &ApplicationStatus{Application: &Application{"", "https://example.com", http.StatusOK, time.Second, "", "Wrong Content", ""}, StatusOk: true, StatusContentOk: false, ActualStatusCode: 200, ActualContent: "Example Domain"}, expectedOutput: "Success: URL https://example.com resolved with 200\nFailure: Expected content Wrong Content did not match ActualContent\n"},
 	}
 
 	for _, test := range tests {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -61,7 +61,7 @@ func TestContainApp(t *testing.T) {
 		{"Valid application", []*a.Application{{Name: "test", URL: "http://test.com", ExpectedStatusCode: http.StatusOK, Timeout: time.Second, ExpectedLocation: "test"}}, "test", true},
 		{"Valid application", []*a.Application{{Name: "test"}}, "test", true},
 		{"Invalid application", []*a.Application{{Name: "test"}}, "test2", false},
-		{"Invalid application", []*a.Application{{"test", "test", 0, 0, "", ""}}, "test2", false},
+		{"Invalid application", []*a.Application{{"test", "test", 0, 0, "", "", ""}}, "test2", false},
 		{"Empty application", []*a.Application{}, "test", false},
 		{"Empty application", []*a.Application{{Name: "test"}}, "", false},
 		{"Empty application", []*a.Application{}, "", false},


### PR DESCRIPTION
Adding CSP header checks is particularly crucial for swiftly detecting and responding to unannounced changes made by vendors. This vigilance is key to maintaining a secure, reliable, and consistent user experience, as well as ensuring that the application's integration with external resources remains intact and secure