### PR TITLE
Makefile: Refactor commands and recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,29 @@
-# Makefile
-
 # Variables
 SLACK_CHANNEL_ID ?=
-SKIP_BUILD ?= 0
+SKIP_BUILD ?= 0 # Set to 1 to skip building the images
 
 # Targets
-.PHONY: all build up down clean test run run-app check_env init conditional-build
+.PHONY: all build container run run-app check_env init test conditional-build
 
-# Default target: build the Docker images
-all: build
+# Default target: build the binary, run the app
+all: build run
 
-# Build Docker images for all services
+# Build binary for aswa
 build:
-	docker-compose build
+	go build -o aswa ./cmd
 
-# Start containers in detached mode
-up:
-	docker-compose up -d
+# Build images for the aswa app and the test container
+container:
+	docker compose build
 
-# Stop and remove containers, networks, and volumes
-down:
-	docker-compose down
+# Run the aswa app
+run:
+	./aswa
 
-# Remove all unused containers, networks, images, and volumes
-clean:
-	docker system prune -a --volumes
-
-# Run tests using the aswa_test container and ensure images are built before running
-test: conditional-build
-	docker-compose run --rm test
-
-# Run the aswa container, remove it after completion, and ensure images are built before running
-run: conditional-build
-	docker-compose run --rm aswa
-
-# Run the synthetic test on the app with the given name
+# Run the synthetic test on the app with the given name in a container
 run-app: conditional-build
 	@if [ -z "$(filter-out $@,$(MAKECMDGOALS))" ]; then echo "Error: Please provide an app name. Usage: make run-app your_app_name_here"; exit 1; fi
-	docker-compose run --rm aswa /aswa $(filter-out $@,$(MAKECMDGOALS))
+	docker compose run --rm aswa /aswa $(filter-out $@,$(MAKECMDGOALS))
 
 # Ignore any targets that are not files
 %:
@@ -45,11 +31,22 @@ run-app: conditional-build
 
 # Check if the required environment variables are set
 check_env:
-	@if [ -z "$(SLACK_CHANNEL_ID)" ]; then echo "SLACK_CHANNEL_ID is not set. Please set it and try again."; exit 1; fi
+	@MISSING_VARS=""; \
+	UNSET_COUNT=0; \
+	if [ -z "$(SLACK_CHANNEL_ID)" ]; then MISSING_VARS="SLACK_CHANNEL_ID"; UNSET_COUNT=$$((UNSET_COUNT + 1)); fi; \
+	if [ -z "$(CLUSTER_INFO)" ]; then MISSING_VARS="$$MISSING_VARS$${MISSING_VARS:+, }CLUSTER_INFO"; UNSET_COUNT=$$((UNSET_COUNT + 1)); fi; \
+	if [ $$UNSET_COUNT -gt 0 ]; then \
+	    echo "$$MISSING_VARS $$([ $$UNSET_COUNT -gt 1 ] && echo 'are' || echo 'is') not set. Please set $$([ $$UNSET_COUNT -gt 1 ] && echo 'them' || echo 'it') and try again."; \
+	    exit 1; \
+	fi
 
 # Initialize the project by checking if the environment variables are set
 init: check_env
 
+# Run tests using the aswa_test container and ensure images are built before running
+test: conditional-build
+	docker compose run --rm test
+
 # Conditionally run the build target based on the value of SKIP_BUILD
 conditional-build:
-	@if [ "$(SKIP_BUILD)" = "0" ]; then $(MAKE) build; fi
+	@if [ "$(SKIP_BUILD)" = "0" ]; then $(MAKE) container; fi


### PR DESCRIPTION
Refactor Makefile: Enhanced Commands and Recipes for Improved Flexibility and Clarity

- Refined the check_env recipe to efficiently handle and report unset environment variables, optimizing for both clarity and accuracy in messaging.
- Updated the conditional-build recipe to better manage the building process based on SKIP_BUILD flag, adding flexibility to the build workflow.
- Streamlined various commands and recipes, improving the overall readability and maintainability of the Makefile.
