### PR TITLE
DEV: Disable getit-ebooks check

### DIFF
--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -24,10 +24,10 @@ applications:
     url: 'https://getit-dev.library.nyu.edu'
     expected_status: 301
     expected_location: 'https://bobcat.library.nyu.edu/primo-explore/citationlinker?vid=NYU'
-  - name: getit-ebooks
-    url: 'https://getit-dev.library.nyu.edu/v0/?genre=bookitem&isbn=9780190280390&issn=&title=Our%20Lady%20of%20everyday%20life:%20la%20Virgen%20de%20Guadalupe%20and%20the%20Catholic%20imagination%20of%20Mexican%20women%20in%20America&volume=&issue=&date=20180101&atitle=&aulast=&spage=&sid=EBSCO:Chicano%20Database&pid=XCHD8493320180101Chicano%20Database'
-    expected_status: 200
-    expected_content: 'ebookcentral.proquest.com'
+#  - name: getit-ebooks
+#    url: 'https://getit-dev.library.nyu.edu/v0/?genre=bookitem&isbn=9780190280390&issn=&title=Our%20Lady%20of%20everyday%20life:%20la%20Virgen%20de%20Guadalupe%20and%20the%20Catholic%20imagination%20of%20Mexican%20women%20in%20America&volume=&issue=&date=20180101&atitle=&aulast=&spage=&sid=EBSCO:Chicano%20Database&pid=XCHD8493320180101Chicano%20Database'
+#    expected_status: 200
+#    expected_content: 'ebookcentral.proquest.com'
   - name: illiad
     url: 'https://dev.ill.library.nyu.edu'
     expected_status: 200


### PR DESCRIPTION
Due to the recent changes this endpoint check has been constantly failing:
```
Failure: URL https://getit-dev.library.nyu.edu/v0/?genre=bookitem&isbn=9780190280390&issn=&title=Our%20Lady%20of%20everyday%20life:%20la%20Virgen%20de%20Guadalupe%20and%20the%20Catholic%20imagination%20of%20Mexican%20women%20in%20America&volume=&issue=&date=20180101&atitle=&aulast=&spage=&sid=EBSCO:Chicano%20Database&pid=XCHD8493320180101Chicano%20Database resolved with 404, expected 200
Failure: Expected content [ebookcentral.proquest.com](http://ebookcentral.proquest.com/) did not match ActualContent
```