### PR TITLE
DEV: Disable getit redirect check

### DIFF
--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -20,10 +20,10 @@ applications:
   - name: campus-media-equipment
     url: 'https://dev.library.nyu.edu/services/campus-media/classrooms/'
     expected_status: 200
-  - name: getit
-    url: 'https://getit-dev.library.nyu.edu'
-    expected_status: 301
-    expected_location: 'https://bobcat.library.nyu.edu/primo-explore/citationlinker?vid=NYU'
+#  - name: getit
+#    url: 'https://getit-dev.library.nyu.edu'
+#    expected_status: 301
+#    expected_location: 'https://bobcat.library.nyu.edu/primo-explore/citationlinker?vid=NYU'
 #  - name: getit-ebooks
 #    url: 'https://getit-dev.library.nyu.edu/v0/?genre=bookitem&isbn=9780190280390&issn=&title=Our%20Lady%20of%20everyday%20life:%20la%20Virgen%20de%20Guadalupe%20and%20the%20Catholic%20imagination%20of%20Mexican%20women%20in%20America&volume=&issue=&date=20180101&atitle=&aulast=&spage=&sid=EBSCO:Chicano%20Database&pid=XCHD8493320180101Chicano%20Database'
 #    expected_status: 200


### PR DESCRIPTION
Due to the recent changes the test has been failing:

`CLUS127DEV1: Failure: URL https://getit-dev.library.nyu.edu/ resolved with 302, expected 301, and redirect location https://search.library.nyu.edu/discovery/citationlinker?vid=01NYU_INST:NYU did not match https://bobcat.library.nyu.edu/primo-explore/citationlinker?vid=NYU`

Will be re-enabled on Jan 3 , 2024