### PR TITLE
DEV: Remove bobcat-search check

### DIFF
--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -13,10 +13,6 @@ applications:
   - name: bobcat-standard
     url: 'https://alephstage.library.nyu.edu'
     expected_status: 200
-  - name: bobcat-search
-    url: 'https://bobcatdev.library.nyu.edu/primo_library/libweb/webservices/rest/primo-explore/v1/pnxs?blendFacetsSeparately=false&getMore=0&inst=NYU&lang=en_US&limit=10&newspapersActive=false&newspapersSearch=false&offset=0&pcAvailability=true&q=any,contains,test&qExclude=&qInclude=&refEntryActive=false&rtaLinks=true&scope=all&searchInFulltextUserSelection=true&skipDelivery=Y&sort=rank&tab=all&vid=NYU'
-    expected_status: 200
-    expected_content: 'test'
   - name: campus-media-equipment
     url: 'https://dev.library.nyu.edu/services/campus-media/classrooms/'
     expected_status: 200


### PR DESCRIPTION
Re: https://bobcatdev.library.nyu.edu/ is scheduled for discontinuation of service
```
CLUS127DEV1: Failure: URL https://bobcatdev.library.nyu.edu/primo_library/libweb/webservices/rest/primo-explore/v1/pnxs?blendFacetsSeparately=false&getMore=0&inst=NYU&lang=en_US&limit=10&newspapersActive=false&newspapersSearch=false&offset=0&pcAvailability=true&q=any,contains,test&qExclude=&qInclude=&refEntryActive=false&rtaLinks=true&scope=all&searchInFulltextUserSelection=true&skipDelivery=Y&sort=rank&tab=all&vid=NYU resolved with 404, expected 200
Failure: Expected content test did not match ActualContent
```
