### PR TITLE
Update Primo VE expected_csp

### DIFF
--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -47,7 +47,7 @@ applications:
   - name: primo-ve
     url: 'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU_DEV'
     expected_status: 200
-    expected_csp: "object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; upgrade-insecure-requests; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
+    expected_csp: "object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net https://youtube.com artic.contentdm.oclc.org search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net https://youtube.com artic.contentdm.oclc.org search.library.nyu.edu; upgrade-insecure-requests; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
   - name: salon
     url: 'https://persistent-dev.library.nyu.edu/arch/does-not-ever-exist'
     expected_status: 400

--- a/config/prod.applications.yml
+++ b/config/prod.applications.yml
@@ -53,7 +53,7 @@ applications:
   - name: primo-ve
     url: 'https://nyu.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU'
     expected_status: 200
-    expected_csp: "object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net www.youtube.com search.library.nyu.edu; upgrade-insecure-requests; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
+    expected_csp: "object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net https://youtube.com artic.contentdm.oclc.org search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net https://youtube.com artic.contentdm.oclc.org search.library.nyu.edu; upgrade-insecure-requests; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
   - name: prod-login
     url: 'https://login.library.nyu.edu/'
     expected_status: 200


### PR DESCRIPTION
Re: Ex-Libris updated their Content-Security-Policy header:
```
~ ➭ curl -I https://nyu.primo.exlibrisgroup.com/discovery/search\?vid\=01NYU_INST:NYU | grep -i "Content-Security-Policy"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  4645    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Content-Security-Policy: object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net https://youtube.com artic.contentdm.oclc.org search.library.nyu.edu; worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net https://youtube.com artic.contentdm.oclc.org search.library.nyu.edu; upgrade-insecure-requests; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint; 
```