### PR TITLE
Add extra logging to contentFailureString

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -291,6 +291,7 @@ func contentSuccessString(results ApplicationStatus) string {
 }
 
 func contentFailureString(results ApplicationStatus) string {
+	log.Printf("DebugMode: %t, IsPrimoVE: %t", DebugMode, IsPrimoVE)
 	if results.ActualContent != "" {
 		if results.Application.Name != "circleCI" {
 			if IsPrimoVE && DebugMode {


### PR DESCRIPTION
Add detailed logging for DebugMode and IsPrimoVE values

To facilitate debugging in Kubernetes environments, this commit adds a logging statement to output the current values of DebugMode and IsPrimoVE. This enhancement aids in verifying the correct application configuration and behavior in different deployment contexts, ensuring that the debug mode and application-specific flags are set as expected.
