### PR TITLE
Add User-Agent header to GET request

### DIFF
--- a/config/saas.applications.yml
+++ b/config/saas.applications.yml
@@ -10,14 +10,14 @@ applications:
     url: 'https://status.circleci.com/api/v2/status.json'
     expected_status: 200
     expected_content: 'All Systems Operational'
-#  - name: lib-guides
-#    url: 'https://guides.nyu.edu/arch'
-#    expected_status: 200
-#    expected_content: 'NYU Libraries Research Guides'
-#  - name: libcal
-#    url: 'https://nyu.libcal.com'
-#    expected_status: 200
-#    expected_content: 'Library Classes & Workshops'
+  - name: lib-guides
+    url: 'https://guides.nyu.edu/arch'
+    expected_status: 200
+    expected_content: 'Research Guides'
+  - name: libcal
+    url: 'https://nyu.libcal.com'
+    expected_status: 200
+    expected_content: 'Library Classes & Workshops'
   - name: library-answers
     url: 'https://library.answers.nyu.edu'
     expected_status: 200

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -130,7 +130,14 @@ func closeResponseBody(Body io.ReadCloser) {
 
 func performGetRequest(test Application, client *http.Client) (*http.Response, error, string, bool) {
 	clientUrl := getClientUrl(test)
-	resp, err := client.Get(clientUrl)
+	req, err := http.NewRequest("GET", clientUrl, nil)
+	if err != nil {
+		return nil, err, "", false
+	}
+
+	req.Header.Set("User-Agent", "ASWA MonitoringService/1.0 (Performs health checks every 15 minutes; contact lib-appdev@nyu.edu for more info)")
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err, "", false
 	}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -135,7 +135,7 @@ func performGetRequest(test Application, client *http.Client) (*http.Response, e
 		return nil, err, "", false
 	}
 
-	req.Header.Set("User-Agent", "ASWA-MonitoringService/1.0 (HealthCheck; contact: lib-appdev@nyu.edu)")
+	req.Header.Set("User-Agent", "ASWA-MonitoringService (HealthCheck; contact: lib-appdev@nyu.edu)")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -277,7 +277,7 @@ func failureString(results ApplicationStatus) string {
 			mismatchDetails = fmt.Sprintf("resolved with %d, expected %d, and redirect location %s did not match %s", actualStatusCode, expectedStatusCode, actualLocation, expectedLocation)
 		} else if statusMatch && !locationMatch {
 			mismatchDetails = fmt.Sprintf("resolved with %d, but redirect location %s did not match %s", actualStatusCode, actualLocation, expectedLocation)
-		} else if !statusMatch && locationMatch {
+		} else if !statusMatch {
 			mismatchDetails = fmt.Sprintf("resolved with %d, expected %d, but redirect location matched", actualStatusCode, expectedStatusCode)
 		}
 	} else if !statusMatch {

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -135,7 +135,7 @@ func performGetRequest(test Application, client *http.Client) (*http.Response, e
 		return nil, err, "", false
 	}
 
-	req.Header.Set("User-Agent", "ASWA MonitoringService/1.0 (Performs health checks every 15 minutes; contact lib-appdev@nyu.edu for more info)")
+	req.Header.Set("User-Agent", "ASWA-MonitoringService/1.0 (HealthCheck; contact: lib-appdev@nyu.edu)")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -147,7 +147,7 @@ func performGetRequest(test Application, client *http.Client) (*http.Response, e
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, resp.Body)
 	if err != nil {
-		log.Println("Error copying response body:", err)
+		return nil, err, "", false
 	}
 
 	actualContent := buf.String()

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -147,6 +147,7 @@ func performGetRequest(test Application, client *http.Client) (*http.Response, e
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, resp.Body)
 	if err != nil {
+		log.Println("Error copying response body:", err)
 		return nil, err, "", false
 	}
 


### PR DESCRIPTION
This PR addresses the issue of receiving 429 (Too Many Requests) responses from a server when making HTTP requests using the ASWA checks. Additionally, it reinstates the checks for `libcal` and `lib-guides` services.