### PR TITLE
 Update Docker image in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 docker-defaults: &docker-defaults
   docker:
-    - image: cimg/base:2024.12
+    - image: cimg/base:2025.01
   working_directory: ~/app
 
 version: 2.1


### PR DESCRIPTION
Update to 2025.01
[cimg/base image tags](https://circleci.com/developer/images/image/cimg/base)