### PR TITLE
Remove retired dev illiad check

### DIFF
--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -26,9 +26,6 @@ applications:
 #    url: 'https://getit-dev.library.nyu.edu/v0/?genre=bookitem&isbn=9780190280390&issn=&title=Our%20Lady%20of%20everyday%20life:%20la%20Virgen%20de%20Guadalupe%20and%20the%20Catholic%20imagination%20of%20Mexican%20women%20in%20America&volume=&issue=&date=20180101&atitle=&aulast=&spage=&sid=EBSCO:Chicano%20Database&pid=XCHD8493320180101Chicano%20Database'
 #    expected_status: 200
 #    expected_content: 'ebookcentral.proquest.com'
-  - name: illiad
-    url: 'https://dev.ill.library.nyu.edu'
-    expected_status: 200
   - name: illiad-dev-new
     url: 'https://ill-dev.library.nyu.edu'
     expected_status: 200


### PR DESCRIPTION
`dev.ill.library.nyu.edu` has been retired