### PR TITLE
Update primo-ve-search-html check after maintenance

### DIFF
--- a/config/primo_ve.applications.yml
+++ b/config/primo_ve.applications.yml
@@ -18,6 +18,6 @@ applications:
   - name: primo-ve-search-html
     url: 'https://search.library.nyu.edu/discovery/search?vid=01NYU_INST:NYU'
     expected_status: 200
-    expected_content: 'src="lib/bundle.js?version=305861f95b"'
+    expected_content: 'src="lib/bundle.js?version=4f34d6cba9"'
 
  


### PR DESCRIPTION
Update the `primo-ve-search-html` check to align with changes introduced during ExLibris maintenance