### PR TITLE
Support optional expected_location for redirect checks

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -187,7 +187,7 @@ func createApplicationStatus(test Application, resp *http.Response, err error, a
 
 		// Determine the statusOk
 		statusOk = compareStatusCodes(resp.StatusCode, test.ExpectedStatusCode) &&
-			compareLocations(actualLocation, test.ExpectedLocation)
+			(test.ExpectedLocation == "" || compareLocations(actualLocation, test.ExpectedLocation))
 
 		// Determine the statusContentOk
 		if test.IsGet() {

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -48,6 +48,7 @@ func TestGetStatus(t *testing.T) {
 	}{
 		{"Success: correct redirect expected", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "https://library.nyu.edu/", "", ""}, true, http.StatusMovedPermanently, "https://library.nyu.edu/", true, "", true, ""},
 		{"Failure: wrong redirect expected", &Application{"", "http://library.nyu.edu", http.StatusFound, 800 * time.Millisecond, "", "", ""}, false, http.StatusMovedPermanently, "", true, "", true, ""},
+		{"Success: 302 redirect with dynamic location (no expected_location)", &Application{"", "http://library.nyu.edu", http.StatusMovedPermanently, 800 * time.Millisecond, "", "", ""}, true, http.StatusMovedPermanently, "https://library.nyu.edu/", true, "", true, ""},
 		{"Success: correct error expected", &Application{"", "https://library.nyu.edu/nopageexistshere", http.StatusNotFound, 600 * time.Millisecond, "", "", ""}, true, http.StatusNotFound, "", true, "", true, ""},
 		{"Success: success status code expected", &Application{"", "https://library.nyu.edu", http.StatusOK, 800 * time.Millisecond, "", "", ""}, true, http.StatusOK, "", true, "", true, ""},
 		{"Failure: wrong status code expected", &Application{"", mockServer.URL + "/wrongstatus", http.StatusOK, 800 * time.Millisecond, "", "", ""}, false, http.StatusNotFound, "", true, "", true, ""},


### PR DESCRIPTION
Re: https://nyu-lib.monday.com/boards/600242918/pulses/18138581449

Modified status validation to make location checking optional when
expected_location is empty, allowing verification of redirects with
dynamic locations while preserving validation when location is specified.