### PR TITLE
Fall back to GET when HEAD probe is unsupported

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -141,18 +141,19 @@ func (test Application) GetStatus() *AppCheckStatus {
 	var actualContent string
 	var statusContentOk bool
 
-	// Phase 1: probe ORIGINAL URL (status + Location)
-	resp, err = performHeadRequest(test, client)
+	// Phase 1: probe ORIGINAL URL (status + Location), preferring HEAD but
+	// falling back to a no-redirect GET when the server does not support HEAD.
+	resp, err = performProbeRequest(test, client)
 	if err != nil {
 		return createApplicationStatus(test, resp, err, "", false)
 	}
 	if resp == nil {
-		return createApplicationStatus(test, resp, fmt.Errorf("nil HEAD response"), "", false)
+		return createApplicationStatus(test, resp, fmt.Errorf("nil probe response"), "", false)
 	}
 	defer closeResponseBody(resp.Body)
 
 	if DebugMode {
-		log.Printf("[HEAD probe] url=%s status=%d location=%q",
+		log.Printf("[probe] url=%s status=%d location=%q",
 			test.URL, resp.StatusCode, resp.Header.Get("Location"))
 	}
 
@@ -255,12 +256,54 @@ func performGetRequest(test Application, client *http.Client) (int, string, stri
 	return resp.StatusCode, finalURL, actualContent, statusContentOk, nil
 }
 
+// performProbeRequest inspects the original URL's status, Location, and headers
+// without following redirects. It prefers HEAD, but falls back to a no-redirect GET
+// when the server does not support HEAD (transport error or 405 Method Not Allowed)
+// so that status/CSP checks are not failed spuriously by HEAD-hostile endpoints.
+func performProbeRequest(test Application, client *http.Client) (*http.Response, error) {
+	resp, err := performHeadRequest(test, client)
+	if !headUnsupported(test, resp, err) {
+		return resp, err
+	}
+	if DebugMode {
+		log.Printf("[probe] HEAD unsupported for url=%s, retrying with GET (err=%v)", test.URL, err)
+	}
+	if resp != nil {
+		closeResponseBody(resp.Body)
+	}
+	return performProbeGetRequest(test, client)
+}
+
+// headUnsupported reports whether a HEAD probe indicates the server does not
+// support HEAD and the check should retry with GET. A 405 is only treated as
+// unsupported when the check does not actually expect a 405.
+func headUnsupported(test Application, resp *http.Response, err error) bool {
+	if err != nil {
+		return true
+	}
+	return resp != nil &&
+		resp.StatusCode == http.StatusMethodNotAllowed &&
+		test.ExpectedStatusCode != http.StatusMethodNotAllowed
+}
+
 func performHeadRequest(test Application, client *http.Client) (*http.Response, error) {
-	resp, err := client.Head(test.URL)
+	req, err := http.NewRequest(http.MethodHead, test.URL, nil)
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	req.Header.Set("User-Agent", userAgent)
+	return client.Do(req)
+}
+
+// performProbeGetRequest issues a GET without following redirects (the client's
+// CheckRedirect prevents following), used as a fallback when HEAD is unsupported.
+func performProbeGetRequest(test Application, client *http.Client) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, test.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	return client.Do(req)
 }
 
 func createApplicationStatus(test Application, resp *http.Response, err error, actualContent string, statusContentOk bool) *AppCheckStatus {

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -666,3 +666,54 @@ func TestGetStatus_RelativeRedirect_AndContent_Failure_ContentMismatch(t *testin
 	assert.Equalf(t, deliveredBody, status.ActualContent,
 		"on mismatch we should capture the full final-page body")
 }
+
+func TestGetStatus_HeadUnsupported_FallsBackToGet(t *testing.T) {
+	// Server rejects HEAD with 405 but answers GET with 200 + a CSP header,
+	// mirroring HEAD-hostile endpoints. The probe should fall back to GET.
+	const csp = "default-src 'self'"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Security-Policy", csp)
+		_, _ = fmt.Fprint(w, "<html><body>OK</body></html>")
+	}))
+	t.Cleanup(srv.Close)
+
+	app := &Application{
+		Name:               "head-unsupported",
+		URL:                srv.URL + "/",
+		ExpectedStatusCode: http.StatusOK,
+		Timeout:            2 * time.Second,
+		ExpectedCSP:        csp,
+	}
+
+	status := app.GetStatus()
+
+	require.NotNil(t, status)
+	assert.Equal(t, http.StatusOK, status.ActualStatusCode, "status should come from the GET fallback, not the HEAD 405")
+	assert.True(t, status.StatusOk, "status check should pass after falling back to GET")
+	assert.True(t, status.StatusCSPOk, "CSP read from the GET fallback response should match")
+}
+
+func TestGetStatus_Expects405_DoesNotFallBack(t *testing.T) {
+	// A check that genuinely expects 405 must not be rerouted to GET.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	t.Cleanup(srv.Close)
+
+	app := &Application{
+		Name:               "expects-405",
+		URL:                srv.URL + "/",
+		ExpectedStatusCode: http.StatusMethodNotAllowed,
+		Timeout:            2 * time.Second,
+	}
+
+	status := app.GetStatus()
+
+	require.NotNil(t, status)
+	assert.Equal(t, http.StatusMethodNotAllowed, status.ActualStatusCode)
+	assert.True(t, status.StatusOk, "a check that expects 405 should pass on the HEAD response")
+}

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -698,8 +698,14 @@ func TestGetStatus_HeadUnsupported_FallsBackToGet(t *testing.T) {
 }
 
 func TestGetStatus_Expects405_DoesNotFallBack(t *testing.T) {
-	// A check that genuinely expects 405 must not be rerouted to GET.
+	// A check that genuinely expects 405 must not be rerouted to GET. GET returns a
+	// distinct 200, so an erroneous fallback would surface as a 200 ActualStatusCode
+	// rather than the expected 405.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}))
 	t.Cleanup(srv.Close)
@@ -714,6 +720,7 @@ func TestGetStatus_Expects405_DoesNotFallBack(t *testing.T) {
 	status := app.GetStatus()
 
 	require.NotNil(t, status)
+	// 405 (not 200) confirms the probe used HEAD and did not fall back to GET.
 	assert.Equal(t, http.StatusMethodNotAllowed, status.ActualStatusCode)
 	assert.True(t, status.StatusOk, "a check that expects 405 should pass on the HEAD response")
 }


### PR DESCRIPTION
The Phase-1 HEAD probe was a hard prerequisite: a transport error or a 405 (e.g. HEAD-hostile endpoints) failed the whole check, and CSP was only read from the HEAD response. Fall back to a no-redirect GET when HEAD is unsupported (405 only when 405 isn't the expected status), and set User-Agent on the probe. Adds two tests.