### PR TITLE
Fix CircleCI gofmt formatting check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,7 @@ jobs:
       - run:
           name: Check formatting
           command: |
-            docker compose run test gofmt -l .
-            test -z $(docker-compose run test gofmt -l .)
-            #docker compose run test golint -set_exit_status
+            test -z "$(docker compose run test gofmt -l .)"
       - run:
           name: Test
           command: |


### PR DESCRIPTION
The Check formatting step mixed docker-compose (v1) with docker compose (v2), ran gofmt twice, and left the gate's command substitution unquoted. Collapse to a single quoted docker compose v2 run that fails on unformatted files.