### PR TITLE
Cap response body read with io.LimitReader

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -19,6 +19,9 @@ const (
 	defaultMaxRedirects = 10
 	envDebugMode        = "DEBUG_MODE"
 	userAgent           = "ASWA-MonitoringService (HealthCheck; contact: lib-appdev@nyu.edu)"
+	// maxResponseBodyBytes caps how much of a response body is read into memory
+	// when matching expected content, bounding memory use on large or hostile responses.
+	maxResponseBodyBytes = 10 << 20 // 10 MiB
 )
 
 var (
@@ -236,7 +239,7 @@ func performGetRequest(test Application, client *http.Client) (int, string, stri
 	defer closeResponseBody(resp.Body)
 
 	buf := new(bytes.Buffer)
-	if _, err := io.Copy(buf, resp.Body); err != nil {
+	if _, err := io.Copy(buf, io.LimitReader(resp.Body, maxResponseBodyBytes)); err != nil {
 		log.Println("Error copying response body:", err)
 		return resp.StatusCode, resp.Request.URL.String(), "", false, err
 	}

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -666,3 +666,33 @@ func TestGetStatus_RelativeRedirect_AndContent_Failure_ContentMismatch(t *testin
 	assert.Equalf(t, deliveredBody, status.ActualContent,
 		"on mismatch we should capture the full final-page body")
 }
+
+func TestGetStatus_OversizedBody_IsCappedAtLimit(t *testing.T) {
+	// The marker sits past maxResponseBodyBytes, so a correctly capped read truncates
+	// before reaching it. Without the cap the marker would be found and content would match.
+	const marker = "MARKER_PAST_THE_CAP"
+	body := make([]byte, maxResponseBodyBytes+len(marker)+1024)
+	for i := range body {
+		body[i] = 'a'
+	}
+	copy(body[len(body)-len(marker):], marker)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	app := &Application{
+		Name:               "oversized",
+		URL:                srv.URL + "/",
+		ExpectedStatusCode: http.StatusOK,
+		Timeout:            5 * time.Second,
+		ExpectedContent:    marker,
+	}
+
+	status := app.GetStatus()
+
+	require.NotNil(t, status)
+	assert.False(t, status.StatusContentOk, "marker beyond the cap must not match a truncated body")
+	assert.Len(t, status.ActualContent, maxResponseBodyBytes, "captured body should be truncated to the cap")
+}


### PR DESCRIPTION
performGetRequest read the entire response body into memory with no limit, so a very large or hostile endpoint could exhaust memory. Wrap the read in io.LimitReader with a 10 MiB cap. Only the content-matching GET path reads the body, and the pages we check are well under 10 MiB, so content matching is unaffected.