### PR TITLE
Clean up dead code in postToSlack

### DIFF
--- a/cmd/synthetic_checks.go
+++ b/cmd/synthetic_checks.go
@@ -24,23 +24,19 @@ type FailingSyntheticTest struct {
 }
 
 // postTestResult constructs a string containing the result of the given test.
-func postTestResult(appStatus a.AppCheckStatus) (string, error) {
+func postTestResult(appStatus a.AppCheckStatus) string {
 	result := appStatus.String()
 	timestamp := time.Now().Local().Format(time.RFC1123Z)
 	log.Printf("Test result generated on %s", timestamp)
 
-	return result, nil
+	return result
 }
 
 func postToSlack(tests []FailingSyntheticTest) error {
 	c.GetSlackWebhookUrl()
 	c.GetClusterInfo()
 	for _, test := range tests {
-		result, err := postTestResult(test.AppStatus)
-		if err != nil {
-			return err
-		}
-		fmt.Println(result)
+		fmt.Println(postTestResult(test.AppStatus))
 	}
 	return nil
 }

--- a/cmd/synthetic_checks.go
+++ b/cmd/synthetic_checks.go
@@ -33,8 +33,6 @@ func postTestResult(appStatus a.AppCheckStatus) string {
 }
 
 func postToSlack(tests []FailingSyntheticTest) error {
-	c.GetSlackWebhookUrl()
-	c.GetClusterInfo()
 	for _, test := range tests {
 		fmt.Println(postTestResult(test.AppStatus))
 	}


### PR DESCRIPTION
Two related cleanups in `cmd/synthetic_checks.go`:

- `postTestResult` always returned a nil error, so the `if err != nil` branch in postToSlack was dead. Return just a string and drop the dead handling.
- `postToSlack` called `c.GetSlackWebhookUrl()` and `c.GetClusterInfo()` only to discard the results (the real Slack post and cluster name are handled in `entrypoint.sh`), so they produced only 'not set' log noise. Removed both calls.