### PR TITLE
Disable CircleCI application check

### DIFF
--- a/config/saas.applications.yml
+++ b/config/saas.applications.yml
@@ -6,11 +6,11 @@ applications:
   - name: ares-webpages
     url: 'https://ares.library.nyu.edu/'
     expected_status: 200
-  - name: circleCI
-    url: 'https://status.circleci.com/api/v2/status.json'
-    expected_status: 200
-    expected_content: 'All Systems Operational'
-    include_actual_content_on_failure: true 
+  # - name: circleCI
+  #   url: 'https://status.circleci.com/api/v2/status.json'
+  #   expected_status: 200
+  #   expected_content: 'All Systems Operational'
+  #   include_actual_content_on_failure: true 
   - name: lib-guides
     url: 'https://guides.nyu.edu/'
     expected_status: 200


### PR DESCRIPTION
Disable the CircleCI application check from the configuration to streamline the application monitoring process.

We are already subscribed to CircleCI status updates, so ASWA checking whether their status API returns 200 and says “all systems operational” feels redundant. That check does not really prove that CircleCI is usable for our workflows; it only proves that their public status endpoint is reachable and reporting green.
If CircleCI has a real incident, we should get notified through their official incident updates. If their status page is wrong or delayed, our ASWA check likely will not give us better signal anyway, since it is reading from the same source. Keeping this check enabled adds noise without much operational value. If we decide we still need CircleCI monitoring later, we should replace this with a more meaningful synthetic check, like verifying that our specific pipeline/API path is usable, not just that the vendor status page says everything is fine. The Redhat check is a good contrast: we specifically target Quay because that is the service we depend on.