### PR TITLE
Update salon dev check

### DIFF
--- a/config/dev.applications.yml
+++ b/config/dev.applications.yml
@@ -47,7 +47,8 @@ applications:
     expected_csp: "object-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net s3.amazonaws.com www.youtube.com youtube.com *.contentdm.oclc.org iiif.nlm.nih.gov search.library.nyu.edu ;worker-src blob: 'self' *.exlibrisgroup.com *.exlibrisgroup.com.cn www.google-analytics.com stats.g.doubleclick.net s3.amazonaws.com www.youtube.com youtube.com artic.contentdm.oclc.org search.library.nyu.edu ;upgrade-insecure-requests; report-uri /infra/CSPReportEndpoint.jsp; report-to csp-report-endpoint;"
   - name: salon
     url: 'https://persistent-dev.library.nyu.edu/arch/does-not-ever-exist'
-    expected_status: 400
+    expected_status: 302
+    expected_location: 'https://guides.nyu.edu/arch/does-not-ever-exist'
   - name: specialcollections-dev
     url: 'https://specialcollections-dev.library.nyu.edu/search'
     expected_status: 200


### PR DESCRIPTION
Companion to NYULibraries/nyulibraries_kubernetes#197.

  PR #197 changes Salon nginx so `/arch/*` now returns `302` to `https://guides.nyu.edu$request_uri`. This PR updates ASWA’s Salon expectations from `400` to the new `302` redirect so the dev/prod checks match the deployed behavior.