### PR TITLE
Update salon prod check

### DIFF
--- a/config/prod.applications.yml
+++ b/config/prod.applications.yml
@@ -43,7 +43,8 @@ applications:
     expected_status: 404
   - name: salon
     url: 'https://persistent.library.nyu.edu/arch/does-not-ever-exist'
-    expected_status: 400
+    expected_status: 302
+    expected_location: 'https://guides.nyu.edu/arch/does-not-ever-exist'
   - name: sfx
     url: 'http://sfx.library.nyu.edu/sfxlcl41'
     expected_status: 301
@@ -61,7 +62,6 @@ applications:
 #    url: 'http://web-pr-proxy1.bobst.nyu.edu/'
 #    expected_status: 301
 #    expected_location: 'https://bobcat.library.nyu.edu/'
-
 
 
 


### PR DESCRIPTION
Companion to NYULibraries/nyulibraries_kubernetes#197.

  PR #197 changes Salon nginx so `/arch/*` now returns `302` to `https://guides.nyu.edu$request_uri`. This PR updates ASWA’s Salon expectations from `400` to the new `302` redirect so the prod checks match the deployed behavior.
