### PR TITLE
Add run counter and rename failure metric for per-app uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ ASWA can post the results of its checks to respective Slack channels (dev, prod,
 
 By default, `OUTPUT_SLACK` is set to `false`. If `OUTPUT_SLACK` is set to `true`, the results are sent to Slack. If `OUTPUT_SLACK` is set to `false`, the results are sent to PAG (Prom Aggregation Gateway). PAG aggregates metrics for Prometheus and is similar in function to Pushgateway but includes metric aggregation capabilities.
 
+### Metrics
+When `OUTPUT_SLACK` is `false`, ASWA pushes two counters to PAG on **every** run:
+
+* `aswa_checks_failed_total{env, app}` — incremented when a synthetic check **fails**.
+* `aswa_checks_run_total{env, app}` — incremented on **every** check (pass or fail).
+
+Because the run counter is recorded even when everything passes, real per-application uptime can be computed in Prometheus/Grafana:
+
+```promql
+uptime % = 1 - increase(aswa_checks_failed_total[$range]) / increase(aswa_checks_run_total[$range])
+```
+
+PAG sums counters across pushes, so both metrics accumulate correctly over time.
 
 ### Deployment
 ASWA is designed to run as a cron job in a Kubernetes (K8s) cluster. 

--- a/cmd/synthetic_checks.go
+++ b/cmd/synthetic_checks.go
@@ -52,6 +52,10 @@ func RunSyntheticTests(appData []*a.Application, targetAppName string) error {
 			found = true // The app was found in the config file
 			appStatus := app.GetStatus()
 			log.Println(appStatus)
+			// Count every check that ran (pass or fail) so uptime has a denominator.
+			if !IsOutputSlack {
+				m.IncrementRunCounter(app.Name)
+			}
 			if !appStatus.StatusOk || !appStatus.StatusContentOk || !appStatus.StatusCSPOk {
 				failingSyntheticTests = append(failingSyntheticTests, FailingSyntheticTest{AppStatus: *appStatus})
 				if !IsOutputSlack {
@@ -72,19 +76,21 @@ func RunSyntheticTests(appData []*a.Application, targetAppName string) error {
 		return err
 	}
 
-	if len(failingSyntheticTests) > 0 {
-		if IsOutputSlack {
+	if IsOutputSlack {
+		if len(failingSyntheticTests) > 0 {
 			return postToSlack(failingSyntheticTests)
 		}
-		// Push metrics to Prom-Aggregation-Gateway if OUTPUT_SLACK is not set
-		if errorProm := m.PushMetrics(); errorProm != nil {
-			log.Printf("Error encountered during metrics push: %v", errorProm)
-			return errorProm // return the error to handle it accordingly
-		}
-		log.Println("Success! Pushed failed test count for all apps to Prom-Aggregation-Gateway")
-	} else {
 		log.Println("No failed tests. No actions taken.")
+		return nil
 	}
+
+	// Metrics mode: always push so the run-count denominator is recorded on every run,
+	// even when all checks pass (PAG sums counters across pushes).
+	if errorProm := m.PushMetrics(); errorProm != nil {
+		log.Printf("Error encountered during metrics push: %v", errorProm)
+		return errorProm // return the error to handle it accordingly
+	}
+	log.Printf("Success! Pushed run and failure counts for all apps to Prom-Aggregation-Gateway (%d failing)", len(failingSyntheticTests))
 	return nil
 }
 

--- a/cmd/synthetic_checks_test.go
+++ b/cmd/synthetic_checks_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -221,4 +222,38 @@ func TestDoCheck(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunSyntheticTestsPushesWhenAllPass covers the metrics-mode behavior change: metrics are
+// pushed on every run, including when nothing fails, so the run-count denominator
+// (aswa_checks_run_total) is always recorded — not only when there is a failure.
+func TestRunSyntheticTestsPushesWhenAllPass(t *testing.T) {
+	t.Setenv(envOutputSlack, "false") // force metrics mode regardless of the ambient environment
+	// Healthy upstream: returns 200, and with no content/location/CSP expectations every check passes.
+	appServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer appServer.Close()
+
+	var pushes int32
+	pag := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&pushes, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer pag.Close()
+	t.Setenv(c.EnvPromAggregationGatewayUrl, pag.URL)
+
+	apps := []*a.Application{
+		{
+			Name:               "healthy",
+			URL:                appServer.URL,
+			ExpectedStatusCode: http.StatusOK,
+			Timeout:            5 * time.Second,
+		},
+	}
+
+	err := RunSyntheticTests(apps, "")
+	assert.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&pushes),
+		"metrics should be pushed even when all checks pass")
 }

--- a/config/primo_ve.applications.yml
+++ b/config/primo_ve.applications.yml
@@ -22,11 +22,8 @@ applications:
   - name: primo-nui-sandbox
     url: 'https://nyu-psb.primo.exlibrisgroup.com/discovery/search?vid=01NYU_INST:NYU'
     expected_status: 200
-    expected_content: 'src="lib/bundle.js?version=af6f613389"'
+    expected_content: 'src="lib/bundle.js?version=cb1d5eb933"'
   - name: primo-nde-sandbox
     url: 'https://nyu-psb.primo.exlibrisgroup.com/nde/home?vid=01NYU_INST:NYU_NDE'
     expected_status: 200
-    expected_content: 'src="main.36e0ea697ee950b7.js"'
-
-
- 
+    expected_content: 'src="main.0325cbc85ed224ec.js"'

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -7,25 +7,47 @@ import (
 	"github.com/prometheus/common/expfmt"
 )
 
-// Define a Prometheus counter to count the number of failed tests
+// Prometheus counters for synthetic checks:
+//   - failedTests counts checks that FAILED.
+//   - checksRun counts every check that RAN (pass or fail). It is the denominator that makes a
+//     real uptime % computable: 1 - increase(aswa_checks_failed_total) / increase(aswa_checks_run_total).
 var (
 	failedTests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "aswa_checks_total",
-			Help: "Failed synthetic test.",
+			Name: "aswa_checks_failed_total",
+			Help: "Failed synthetic checks.",
+		},
+		[]string{"env", "app"},
+	)
+
+	checksRun = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "aswa_checks_run_total",
+			Help: "Total synthetic checks run (pass or fail).",
 		},
 		[]string{"env", "app"},
 	)
 )
 
 func init() {
-	prometheus.MustRegister(failedTests)
+	prometheus.MustRegister(failedTests, checksRun)
 }
 
-// IncrementFailedTestsCounter increments the counter for a given app
+// IncrementFailedTestsCounter increments the failure counter for a given app.
 func IncrementFailedTestsCounter(app string) {
 	env := c.GetEnvironmentName()
 	failedTests.WithLabelValues(env, app).Inc()
+}
+
+// IncrementRunCounter increments the run counter for a given app. Call it on every
+// check (pass or fail) so uptime can be derived as 1 - failures/runs. It also ensures
+// the app's failure series (aswa_checks_failed_total) exists, initialized to 0 when the app
+// has never failed, so always-healthy apps still produce a series for the uptime formula
+// 1 - increase(aswa_checks_failed_total) / increase(aswa_checks_run_total).
+func IncrementRunCounter(app string) {
+	env := c.GetEnvironmentName()
+	checksRun.WithLabelValues(env, app).Inc()
+	failedTests.WithLabelValues(env, app) // create the failure series at 0 if it does not exist yet
 }
 
 // PushMetrics pushes all collected metrics to the PAG.
@@ -33,6 +55,7 @@ func PushMetrics() error {
 	textFormat := expfmt.NewFormat(expfmt.TypeTextPlain)
 	pusher := push.New(c.GetPromAggregationgatewayUrl(), "monitoring").
 		Collector(failedTests).
+		Collector(checksRun).
 		Format(textFormat)
 	if err := pusher.Push(); err != nil {
 		return err

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	c "github.com/NYULibraries/aswa/pkg/config"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 func TestPushMetrics(t *testing.T) {
@@ -39,8 +41,9 @@ func TestPushMetrics(t *testing.T) {
 			// Setup environment variable to mock the pushgateway URL
 			t.Setenv(c.EnvPromAggregationGatewayUrl, server.URL)
 
-			// Increment a test counter to simulate metrics that would be pushed
+			// Increment test counters to simulate metrics that would be pushed
 			IncrementFailedTestsCounter("testApp")
+			IncrementRunCounter("testApp")
 
 			// Call PushMetrics to attempt to push the test counter to the mock server
 			err := PushMetrics()
@@ -56,5 +59,52 @@ func TestPushMetrics(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// collectedSeries counts the series a collector currently holds, without creating any
+// (unlike WithLabelValues, which would add the child it looks up).
+func collectedSeries(coll prometheus.Collector) int {
+	ch := make(chan prometheus.Metric)
+	go func() {
+		coll.Collect(ch)
+		close(ch)
+	}()
+	n := 0
+	for range ch {
+		n++
+	}
+	return n
+}
+
+func counterValue(t *testing.T, counter prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := counter.Write(&m); err != nil {
+		t.Fatalf("write counter: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+// TestIncrementRunCounterInitializesFailureSeries verifies that recording a run for an app
+// that has never failed still creates its aswa_checks_failed_total series at 0, so the uptime
+// formula returns a value (100%) for always-healthy apps instead of no series at all.
+func TestIncrementRunCounterInitializesFailureSeries(t *testing.T) {
+	const app = "never-fails-unique"
+
+	failuresBefore := collectedSeries(failedTests)
+
+	IncrementRunCounter(app)
+
+	if got := collectedSeries(failedTests); got != failuresBefore+1 {
+		t.Errorf("expected IncrementRunCounter to create the failure series for %q (count %d -> %d)", app, failuresBefore, got)
+	}
+
+	env := c.GetEnvironmentName()
+	if v := counterValue(t, failedTests.WithLabelValues(env, app)); v != 0 {
+		t.Errorf("expected failure counter for %q to be initialized to 0 (not incremented), got %v", app, v)
+	}
+	if v := counterValue(t, checksRun.WithLabelValues(env, app)); v != 1 {
+		t.Errorf("expected run counter for %q to be 1, got %v", app, v)
 	}
 }


### PR DESCRIPTION
Adds a run counter so ASWA can report a real per-app uptime %, and renames the failure counter to match what it actually measures.

- Add `aswa_checks_run_total{env,app}` — incremented on every check, pass or fail. It's the denominator for uptime: `1 - increase(aswa_checks_failed_total) / increase(aswa_checks_run_total)`.
- Rename `aswa_checks_total` → `aswa_checks_failed_total` — same `{env,app}` counter, name now reflects that it counts failures.
- Seed the failure series at 0 for every app that runs, so always-healthy apps emit a series and report 100% instead of being absent from the query.

## Breaking
`aswa_checks_total` no longer exists. Anything querying it — alerts, saved Grafana panels — must move to `aswa_checks_failed_total`.

## Dependency — merge order (lockstep)
Merge this first. The monitoring repo's [PR #200](https://github.com/NYULibraries/nyulibraries_kubernetes/pull/200) renames the same metric in the clus136lab1 alert rule and adds the uptime dashboard; both reference `aswa_checks_failed_total` / `aswa_checks_run_total`, which only exist once `:main` runs this image.
